### PR TITLE
Limit Image Title and Description Length

### DIFF
--- a/src/app/components/artwork-upload/ArtworkUploadModalForm.tsx
+++ b/src/app/components/artwork-upload/ArtworkUploadModalForm.tsx
@@ -52,6 +52,7 @@ export function ArtworkUploadModalForm() {
           type="text"
           className="form-control"
           id="imageDescription"
+          maxLength={300}
         />
       </div>
       <div className="mb-3 input-group">

--- a/src/app/components/artwork-upload/ArtworkUploadModalForm.tsx
+++ b/src/app/components/artwork-upload/ArtworkUploadModalForm.tsx
@@ -40,6 +40,7 @@ export function ArtworkUploadModalForm() {
           type="text"
           className="form-control"
           id="imageTitle"
+          maxLength={60}
         />
       </div>
       <div className="mb-3">


### PR DESCRIPTION
Title length for images is unlimited, as is description length. This PR aims to fix this by limiting title to 60 characters and description to 400.
Before fix (it keeps going forever):
![image](https://github.com/Sabbasn/ArtworkProject/assets/59234024/e42c329f-07f7-4f86-b867-c0411a1dac65)

After fix:
<img width="306" alt="image" src="https://github.com/Sabbasn/ArtworkProject/assets/59234024/5151dc5e-00ef-46d6-9b5b-6446b283e127">
