### PR TITLE
inital concept of aspect ratio

### DIFF
--- a/src/app/components/home/artwork/ArtworkImage.tsx
+++ b/src/app/components/home/artwork/ArtworkImage.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+interface ArtworkProp{
+    imageData: string
+}
+
+export default function ArtworkImage(props: ArtworkProp){
+    return (
+        <div className="image-component d-flex align-items-center justify-content-center flex-column">
+            <p className="view-image-text">View full image</p>
+            <Image
+            src={props.imageData}
+            alt="something"
+            className="card-img-top"
+            width="0"
+            height="0"
+            sizes="100vw"
+            style={{ width: "100%", height: "auto" }}
+            />
+            <Image
+            src={props.imageData}
+            alt="something"
+            className="card-img-glow"
+            width="0"
+            height="0"
+            sizes="100vw"
+            style={{ width: "100%", height: "auto" }}
+            />
+      </div>
+    )
+}

--- a/src/app/components/home/artwork/ArtworkPost.css
+++ b/src/app/components/home/artwork/ArtworkPost.css
@@ -93,12 +93,16 @@
   animation: rotateOut 200ms linear;
   animation-iteration-count: 1;
 }
+
 .card:hover{
   animation: rotateIn 200ms linear;
   filter: grayscale(0%);
   transition: 300ms ease-in-out;
   animation-iteration-count: 1;
+}
 
+.image-component:hover{
+  cursor: pointer;
 }
 
 .card-img-top, .card-img-glow{
@@ -107,11 +111,26 @@
   transition: all 300ms ease-in-out;
 }
 
-.card:hover > .card-img-top, .card-img-glow{
+.view-image-text{
+  position: absolute;
+  opacity: 0;
+  transition: all 300ms ease-in-out;
+  padding: 20px;
+  background-color: rgba(0, 0, 0, 0.6);
+  border-radius: 10px;
+  border: 1px solid white;
+}
+
+.card:hover > .image-component > .view-image-text{
+  opacity: 1;
+  transition: all 300ms ease-in-out;
+}
+
+/* .card:hover > .card-img-top, .card-img-glow{
   aspect-ratio: auto;
   object-fit: auto;
   transition: all 300ms ease-in-out;
-}
+} */
 
 
 .card-img-glow{

--- a/src/app/components/home/artwork/ArtworkPost.css
+++ b/src/app/components/home/artwork/ArtworkPost.css
@@ -141,7 +141,7 @@
   transition: 300ms ease-in-out;
 }
 
-.card:hover > .card-img-glow{
+.card:hover > .image-component > .card-img-glow{
   opacity: 0.5;
   transition: 300ms ease-in-out;
 }

--- a/src/app/components/home/artwork/ArtworkPost.css
+++ b/src/app/components/home/artwork/ArtworkPost.css
@@ -121,7 +121,7 @@
   border: 1px solid white;
 }
 
-.card:hover > .image-component > .view-image-text{
+.image-component:hover > .view-image-text{
   opacity: 1;
   transition: all 300ms ease-in-out;
 }

--- a/src/app/components/home/artwork/ArtworkPost.css
+++ b/src/app/components/home/artwork/ArtworkPost.css
@@ -101,6 +101,19 @@
 
 }
 
+.card-img-top, .card-img-glow{
+  aspect-ratio: 1/1;
+  object-fit: cover;
+  transition: all 300ms ease-in-out;
+}
+
+.card:hover > .card-img-top, .card-img-glow{
+  aspect-ratio: auto;
+  object-fit: auto;
+  transition: all 300ms ease-in-out;
+}
+
+
 .card-img-glow{
   position: absolute;
   z-index: -2;

--- a/src/app/components/home/artwork/ArtworkPost.tsx
+++ b/src/app/components/home/artwork/ArtworkPost.tsx
@@ -18,24 +18,27 @@ export default function ArtWorkPost(props: ArtWorkPostProps) {
 
   return (
     <div className="card" style={{ maxWidth: "400px", width: "100%" }}>
-      <Image
-        src={props.artwork.fileData}
-        alt="something"
-        className="card-img-top"
-        width="0"
-        height="0"
-        sizes="100vw"
-        style={{ width: "100%", height: "auto" }}
-      />
-      <Image
-        src={props.artwork.fileData}
-        alt="something"
-        className="card-img-glow"
-        width="0"
-        height="0"
-        sizes="100vw"
-        style={{ width: "100%", height: "auto" }}
-      />
+      <div className="image-component d-flex align-items-center justify-content-center flex-column">
+        <p className="view-image-text">View full image</p>
+        <Image
+          src={props.artwork.fileData}
+          alt="something"
+          className="card-img-top"
+          width="0"
+          height="0"
+          sizes="100vw"
+          style={{ width: "100%", height: "auto" }}
+        />
+        <Image
+          src={props.artwork.fileData}
+          alt="something"
+          className="card-img-glow"
+          width="0"
+          height="0"
+          sizes="100vw"
+          style={{ width: "100%", height: "auto" }}
+        />
+      </div>
       <div className="card-body d-flex align-items-center justify-content-center">
         <ul
           className="card-body-ul d-flex flex-column container"

--- a/src/app/components/home/artwork/ArtworkPost.tsx
+++ b/src/app/components/home/artwork/ArtworkPost.tsx
@@ -1,12 +1,11 @@
 import { ArtworkPostButton } from "./ArtworkPostButton";
 import "./ArtworkPost.css";
 import { useState } from "react";
-import Image from "next/image";
+import ArtworkImage from "./ArtworkImage";
 
 interface ArtWorkPostProps {
   artwork: Artwork;
-}
-
+}  
 function formatDate(date: Date){
   const datestring:string = date.toLocaleDateString();
   const timestring:string = date.toLocaleTimeString();
@@ -15,30 +14,9 @@ function formatDate(date: Date){
 
 export default function ArtWorkPost(props: ArtWorkPostProps) {
   const [isLiked, setIsLiked] = useState(false);
-
   return (
     <div className="card" style={{ maxWidth: "400px", width: "100%" }}>
-      <div className="image-component d-flex align-items-center justify-content-center flex-column">
-        <p className="view-image-text">View full image</p>
-        <Image
-          src={props.artwork.fileData}
-          alt="something"
-          className="card-img-top"
-          width="0"
-          height="0"
-          sizes="100vw"
-          style={{ width: "100%", height: "auto" }}
-        />
-        <Image
-          src={props.artwork.fileData}
-          alt="something"
-          className="card-img-glow"
-          width="0"
-          height="0"
-          sizes="100vw"
-          style={{ width: "100%", height: "auto" }}
-        />
-      </div>
+      <ArtworkImage imageData={props.artwork.fileData}/>
       <div className="card-body d-flex align-items-center justify-content-center">
         <ul
           className="card-body-ul d-flex flex-column container"


### PR DESCRIPTION
WIP of aspect ratio fix for artworks, closes #2 

Currently creates a 1:1 aspect ratio image for all images.
<img width="827" alt="image" src="https://github.com/Sabbasn/ArtworkProject/assets/59234024/c545553b-3905-4bc3-9498-128b044f8a71">

However due to the constraints on the .card itself it fits the image withing the boundaries of the .card when showing the full aspect ratio image, resulting in this:
<img width="830" alt="image" src="https://github.com/Sabbasn/ArtworkProject/assets/59234024/a3591d42-df9b-4a1b-8ecf-b6980bc13a37">

It might be better to scale it up to show on a bigger portion of the screen? Need to discuss this before this PR is reviewed and merged @Sabbasn .